### PR TITLE
Feat/scan history

### DIFF
--- a/src/app/(protected)/scan-history/page.tsx
+++ b/src/app/(protected)/scan-history/page.tsx
@@ -1,7 +1,8 @@
+import ScanHistoryView from "@/view/scan-history/ScanHistoryView";
 import React from "react";
 
 const ScanHistory = () => {
-  return <div>ScanHistory</div>;
+  return <ScanHistoryView />;
 };
 
 export default ScanHistory;

--- a/src/app/(protected)/scan-history/page.tsx
+++ b/src/app/(protected)/scan-history/page.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const ScanHistory = () => {
+  return <div>ScanHistory</div>;
+};
+
+export default ScanHistory;

--- a/src/hooks/use-scan-history.ts
+++ b/src/hooks/use-scan-history.ts
@@ -1,0 +1,35 @@
+import { useQuery, UseQueryResult } from "@tanstack/react-query";
+import { getScans } from "@/services/scan.services";
+import { ApiResponse } from "@/types/common.types";
+import { ScanRecord } from "@/types/scan.types";
+
+interface UseScanHistoryOptions {
+  accessToken?: string;
+  page: number;
+  pageSize?: number;
+  enabled?: boolean;
+}
+
+export function useScanHistory({
+  accessToken,
+  page,
+  pageSize = 5,
+  enabled = true,
+}: UseScanHistoryOptions): UseQueryResult<ApiResponse<ScanRecord[] | null>> {
+  return useQuery<ApiResponse<ScanRecord[] | null>>({
+    queryKey: ["scans", page, pageSize, accessToken],
+    queryFn: async () => {
+      if (!accessToken) {
+        return {
+          success: false,
+          message: "Not authenticated",
+          payload: null,
+        } as ApiResponse<null>;
+      }
+      return getScans(accessToken, page, pageSize);
+    },
+    enabled: enabled && !!accessToken,
+    staleTime: 30_000,
+    refetchOnWindowFocus: false,
+  });
+}

--- a/src/services/scan.services.ts
+++ b/src/services/scan.services.ts
@@ -3,6 +3,7 @@ import { ApiResponse } from "@/types/common.types";
 import {
   CreateScanResponsePayload,
   ModelHealthPayload,
+  ScanRecord,
 } from "@/types/scan.types";
 
 export async function createScan(
@@ -43,6 +44,32 @@ export async function getModelHealth(): Promise<
       headers: { Accept: "application/json" },
     });
     return response.data as ApiResponse<ModelHealthPayload>;
+  } catch (error) {
+    const axiosError = error as AxiosError;
+    const errorPayload = axiosError.response?.data || {
+      message: "Something went wrong",
+      success: false,
+      payload: null,
+    };
+    return errorPayload as ApiResponse<null>;
+  }
+}
+
+export async function getScans(
+  accessToken: string,
+  page: number = 1,
+  pageSize: number = 5
+): Promise<ApiResponse<ScanRecord[] | null>> {
+  try {
+    const endpoint = `${process.env.NEXT_PUBLIC_API_URL}/scans`;
+    const response = await axios.get(endpoint, {
+      params: { page, page_size: pageSize },
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+    return response.data as ApiResponse<ScanRecord[]>;
   } catch (error) {
     const axiosError = error as AxiosError;
     const errorPayload = axiosError.response?.data || {

--- a/src/types/scan.types.ts
+++ b/src/types/scan.types.ts
@@ -10,7 +10,7 @@ export interface ScanRecord {
   image_url: string;
   predicted_label: string;
   confidence: number; // 0..1
-  top_k: TopKItem[];
+  top_k?: TopKItem[]; // optional in history list responses
   model_version: string;
   created_at: string; // ISO timestamp
 }
@@ -45,3 +45,5 @@ export interface ModelHealthPayload {
   img_size: [number, number];
   model_version: string;
 }
+
+export type ScanHistoryResponsePayload = ScanRecord[];

--- a/src/view/scan-history/ScanHistoryView.tsx
+++ b/src/view/scan-history/ScanHistoryView.tsx
@@ -1,0 +1,107 @@
+"use client";
+import React, { useState } from "react";
+import { useSession } from "next-auth/react";
+import { useScanHistory } from "@/hooks/use-scan-history";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+const PAGE_SIZE = 5;
+
+const ScanHistoryView = () => {
+  const { data: session } = useSession();
+  const accessToken = session?.accessToken;
+  const [page, setPage] = useState(1);
+
+  const query = useScanHistory({ accessToken, page, pageSize: PAGE_SIZE });
+
+  const totalPages = query.data?.meta?.total_pages || 1;
+  const scans = query.data?.payload || [];
+
+  return (
+    <div className="space-y-4 mx-auto max-w-7xl px-4 py-6 lg:py-8 ">
+      <Card>
+        <CardHeader>
+          <CardTitle>Scan History</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {query.isLoading && (
+            <p className="text-sm text-muted-foreground">Loading scans...</p>
+          )}
+          {query.isError && (
+            <p className="text-sm text-destructive">
+              Error loading scan history.
+            </p>
+          )}
+          {!query.isLoading && !query.isError && scans.length === 0 && (
+            <p className="text-sm text-muted-foreground">No scans found.</p>
+          )}
+
+          {scans.length > 0 && (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-left border-b">
+                    <th className="py-2 pr-4">Image</th>
+                    <th className="py-2 pr-4">Prediction</th>
+                    <th className="py-2 pr-4">Confidence</th>
+                    <th className="py-2 pr-4">Model</th>
+                    <th className="py-2 pr-4">Date</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {scans.map((scan) => (
+                    <tr key={scan.id} className="border-b last:border-none">
+                      <td className="py-2 pr-4">
+                        <img
+                          src={scan.image_url}
+                          alt={scan.predicted_label}
+                          className="h-12 w-12 object-cover rounded-md border"
+                        />
+                      </td>
+                      <td className="py-2 pr-4 font-medium">
+                        {scan.predicted_label}
+                      </td>
+                      <td className="py-2 pr-4">
+                        {(scan.confidence * 100).toFixed(1)}%
+                      </td>
+                      <td className="py-2 pr-4">{scan.model_version}</td>
+                      <td className="py-2 pr-4">
+                        {new Date(scan.created_at).toLocaleString()}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          <div className="flex items-center justify-between pt-4">
+            <p className="text-xs text-muted-foreground">
+              Page {page} of {totalPages}
+            </p>
+            <div className="space-x-2">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page === 1 || query.isFetching}
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+              >
+                Previous
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page === totalPages || query.isFetching}
+                onClick={() => setPage((p) => (p < totalPages ? p + 1 : p))}
+              >
+                Next
+              </Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default ScanHistoryView;

--- a/src/view/scan/ScanView.tsx
+++ b/src/view/scan/ScanView.tsx
@@ -7,10 +7,12 @@ import { ModelStatusCard } from "@/components/scan/ModelStatusCard";
 import { Button } from "@/components/ui/button";
 import { History } from "lucide-react";
 import useScanStore from "@/store/scan.store";
+import { useRouter } from "next/navigation";
 
 const ScanView = () => {
   const scanData = useScanStore((state) => state.scanData);
   const isScanDataLoading = useScanStore((state) => state.isScanDataLoading);
+  const router = useRouter();
   return (
     <main className="mx-auto max-w-7xl px-4 py-6 lg:py-8">
       {/* Header strip */}
@@ -23,10 +25,10 @@ const ScanView = () => {
         </div>
         <Button
           variant="ghost"
-          className="gap-2"
+          className="gap-2 cursor-pointer"
           title="UI only"
-          disabled
           aria-label="History"
+          onClick={() => router.push("/scan-history")}
         >
           <History className="size-4" /> History
         </Button>


### PR DESCRIPTION
This pull request introduces a new scan history feature, allowing users to view their previous scan records with pagination. The main changes include implementing the backend integration for fetching scan history, updating types to support the new response structure, and adding a new UI view for displaying the scan history. Additionally, the scan page now links to the scan history view.

**Scan History Feature Implementation**

* Added the `ScanHistoryView` component and corresponding route at `/scan-history`, displaying paginated scan records in a table with navigation controls. [[1]](diffhunk://#diff-4b3491aae6501721eda245393387452ff392607e43d4a3ce825334ec7bfc8a04R1-R8) [[2]](diffhunk://#diff-9c79080bd17d1769840d1e6a65305df32f659ddc0156a69b6b69f60ace78da29R1-R107)
* Created the `useScanHistory` React hook to fetch paginated scan history from the backend using the user's access token, leveraging React Query for data management.
* Implemented the `getScans` service function to retrieve scan history from the API, handling authentication and error responses.
* Updated the `ScanRecord` type to make the `top_k` field optional, reflecting its absence in history responses, and introduced a new `ScanHistoryResponsePayload` type. [[1]](diffhunk://#diff-e55c35f12a9b850b860be5c7ae91aa276b56e11eab6c9fedf072e5e38e964586L13-R13) [[2]](diffhunk://#diff-e55c35f12a9b850b860be5c7ae91aa276b56e11eab6c9fedf072e5e38e964586R48-R49)

**UI Integration**

* Modified the scan page (`ScanView`) to enable navigation to the scan history view by making the History button interactive. [[1]](diffhunk://#diff-efbb29e57354c11caaf8db3779a486e9bb0933e48b6e23a76fbce83348be835dR10-R15) [[2]](diffhunk://#diff-efbb29e57354c11caaf8db3779a486e9bb0933e48b6e23a76fbce83348be835dL26-R31)