### PR TITLE
Pagination meta interface improvements

### DIFF
--- a/src/types/common.types.ts
+++ b/src/types/common.types.ts
@@ -6,8 +6,11 @@ export interface ApiResponse<T> {
 }
 
 export interface PaginationMeta {
-  page: number;
-  page_size: number;
-  total_pages: number;
-  total_items: number;
+  page: number; // current page (1-based)
+  page_size: number; // items per page
+  // Unified support:
+  // Backend may send (total) OR (total_items) OR (total_pages + total_items)
+  total?: number; // total items (preferred simple form)
+  total_items?: number; // alternative name for total items
+  total_pages?: number; // when backend precomputes pages
 }


### PR DESCRIPTION
This pull request improves pagination handling in the scan history view by making it more robust to variations in backend responses. The changes ensure that pagination works correctly whether the backend supplies total item counts, total pages, or both, and gracefully falls back when information is missing.

**Pagination meta interface improvements:**

* Updated the `PaginationMeta` interface in `common.types.ts` to support multiple backend response formats, allowing for `total`, `total_items`, and/or `total_pages` fields. This makes the frontend compatible with different backend pagination implementations.

**Pagination logic and UI enhancements:**

* Refactored pagination calculation in `ScanHistoryView.tsx` to derive total pages from total items when available, and to handle cases where only partial pagination data is provided.
* Improved UI messaging to display "Page X of Y" only when total pages are known, otherwise just "Page X".
* Updated previous/next button logic to enable/disable navigation based on available pagination metadata and inferred page boundaries, preventing navigation errors when data is incomplete. [[1]](diffhunk://#diff-9c79080bd17d1769840d1e6a65305df32f659ddc0156a69b6b69f60ace78da29L17-R31) [[2]](diffhunk://#diff-9c79080bd17d1769840d1e6a65305df32f659ddc0156a69b6b69f60ace78da29L80-R107)