### PR TITLE
Scan Details Fetching and Display

### DIFF
--- a/src/app/(protected)/scan-history/[scanId]/page.tsx
+++ b/src/app/(protected)/scan-history/[scanId]/page.tsx
@@ -1,11 +1,10 @@
 import ScanHistoryInnerPage from "@/view/scan-history-inner-page/ScanHistoryInnerPage";
 
-export default async function ScanInnerPage({
+export default function ScanInnerPage({
   params,
 }: {
-  params: Promise<{ scanId: string }>;
+  params: { scanId: string };
 }) {
-  const { scanId } = await params;
-
+  const { scanId } = params;
   return <ScanHistoryInnerPage scanId={scanId} />;
 }

--- a/src/hooks/use-scan-details.ts
+++ b/src/hooks/use-scan-details.ts
@@ -1,0 +1,39 @@
+import { useQuery, UseQueryResult } from "@tanstack/react-query";
+import { getScanById } from "@/services/scan.services";
+import { ApiResponse } from "@/types/common.types";
+import { DiseaseInfo, ScanRecord, TreatmentItem } from "@/types/scan.types";
+
+interface UseScanDetailsOptions {
+  accessToken?: string;
+  scanId?: string;
+  enabled?: boolean;
+}
+
+export function useScanDetails({
+  accessToken,
+  scanId,
+  enabled = true,
+}: UseScanDetailsOptions): UseQueryResult<
+  ApiResponse<{
+    scan: ScanRecord;
+    disease: DiseaseInfo;
+    treatments: TreatmentItem[];
+  } | null>
+> {
+  return useQuery({
+    queryKey: ["scan", scanId, accessToken],
+    queryFn: async () => {
+      if (!accessToken || !scanId) {
+        return {
+          success: false,
+          message: "Missing auth or scan id",
+          payload: null,
+        } as ApiResponse<null>;
+      }
+      return getScanById(accessToken, scanId);
+    },
+    enabled: enabled && !!accessToken && !!scanId,
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+  });
+}

--- a/src/services/scan.services.ts
+++ b/src/services/scan.services.ts
@@ -80,3 +80,37 @@ export async function getScans(
     return errorPayload as ApiResponse<null>;
   }
 }
+
+export async function getScanById(
+  accessToken: string,
+  scanId: string
+): Promise<
+  ApiResponse<{
+    scan: ScanRecord;
+    disease: import("@/types/scan.types").DiseaseInfo;
+    treatments: import("@/types/scan.types").TreatmentItem[];
+  } | null>
+> {
+  try {
+    const endpoint = `${process.env.NEXT_PUBLIC_API_URL}/scans/${scanId}`;
+    const response = await axios.get(endpoint, {
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+    return response.data as ApiResponse<{
+      scan: ScanRecord;
+      disease: import("@/types/scan.types").DiseaseInfo;
+      treatments: import("@/types/scan.types").TreatmentItem[];
+    }>;
+  } catch (error) {
+    const axiosError = error as AxiosError;
+    const errorPayload = axiosError.response?.data || {
+      message: "Something went wrong",
+      success: false,
+      payload: null,
+    };
+    return errorPayload as ApiResponse<null>;
+  }
+}

--- a/src/view/scan-history-inner-page/ScanHistoryInnerPage.tsx
+++ b/src/view/scan-history-inner-page/ScanHistoryInnerPage.tsx
@@ -1,13 +1,141 @@
+"use client";
 import React from "react";
+import { useSession } from "next-auth/react";
+import { useScanDetails } from "@/hooks/use-scan-details";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
 
 interface ScanHistoryInnerPageProps {
   scanId: string;
 }
 
-const ScanHistoryInnerPage: React.FC<ScanHistoryInnerPageProps> = (props) => {
-  const { scanId } = props;
+const ScanHistoryInnerPage: React.FC<ScanHistoryInnerPageProps> = ({
+  scanId,
+}) => {
+  const { data: session } = useSession();
+  const accessToken = session?.accessToken;
+  const query = useScanDetails({ accessToken, scanId });
 
-  return <div>ScanHistoryInnerPage</div>;
+  const data = query.data?.payload;
+  const scan = data?.scan;
+  const disease = data?.disease;
+  const treatments = data?.treatments || [];
+
+  return (
+    <div className="space-y-6 mx-auto max-w-5xl px-4 py-6 lg:py-8">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Scan Details</h1>
+        <Button asChild variant="outline" size="sm">
+          <Link href="/protected/scan-history">Back to history</Link>
+        </Button>
+      </div>
+
+      {query.isLoading && (
+        <p className="text-sm text-muted-foreground">Loading scan details...</p>
+      )}
+      {query.isError && (
+        <p className="text-sm text-destructive">Error loading scan details.</p>
+      )}
+      {!query.isLoading && !query.isError && !scan && (
+        <p className="text-sm text-muted-foreground">Scan not found.</p>
+      )}
+
+      {scan && (
+        <div className="grid gap-6 md:grid-cols-12">
+          <Card className="md:col-span-5">
+            <CardHeader>
+              <CardTitle>Image</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <img
+                src={scan.image_url}
+                alt={scan.predicted_label}
+                className="w-full max-h-96 object-contain rounded-md border"
+              />
+              <div className="mt-4 space-y-1 text-sm">
+                <p>
+                  <span className="font-medium">Predicted:</span>{" "}
+                  {scan.predicted_label}
+                </p>
+                <p>
+                  <span className="font-medium">Confidence:</span>{" "}
+                  {(scan.confidence * 100).toFixed(2)}%
+                </p>
+                <p>
+                  <span className="font-medium">Model:</span>{" "}
+                  {scan.model_version}
+                </p>
+                <p>
+                  <span className="font-medium">Created:</span>{" "}
+                  {new Date(scan.created_at).toLocaleString()}
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card className="md:col-span-7">
+            <CardHeader>
+              <CardTitle>Disease & Treatments</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              {disease && (
+                <div>
+                  <h2 className="font-medium mb-1">{disease.display_name}</h2>
+                  <p className="text-sm leading-relaxed text-muted-foreground whitespace-pre-line">
+                    {disease.description}
+                  </p>
+                </div>
+              )}
+
+              {scan.top_k && scan.top_k.length > 0 && (
+                <div>
+                  <h3 className="text-sm font-medium mb-2">Top Predictions</h3>
+                  <ul className="space-y-1 text-sm">
+                    {scan.top_k.map((item) => (
+                      <li
+                        key={item.label}
+                        className="flex items-center justify-between"
+                      >
+                        <span>{item.label}</span>
+                        <span className="tabular-nums">
+                          {(item.confidence * 100).toFixed(2)}%
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {treatments.length > 0 && (
+                <div>
+                  <h3 className="text-sm font-medium mb-2">Treatments</h3>
+                  <ul className="space-y-3">
+                    {treatments.map((t) => (
+                      <li key={t.id} className="rounded-md border p-3">
+                        <div className="flex items-center justify-between mb-1">
+                          <span className="font-medium">{t.title}</span>
+                          <span className="text-xs uppercase tracking-wide text-muted-foreground">
+                            {t.type}
+                          </span>
+                        </div>
+                        <p className="text-xs leading-relaxed mb-1 whitespace-pre-line">
+                          {t.instructions}
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          Dosage: {t.dosage}
+                        </p>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </div>
+  );
 };
 
 export default ScanHistoryInnerPage;

--- a/src/view/scan-history/ScanHistoryView.tsx
+++ b/src/view/scan-history/ScanHistoryView.tsx
@@ -63,16 +63,33 @@ const ScanHistoryView = () => {
                 </thead>
                 <tbody>
                   {scans.map((scan) => (
-                    <tr key={scan.id} className="border-b last:border-none">
+                    <tr
+                      key={scan.id}
+                      className="border-b last:border-none hover:bg-muted/40 cursor-pointer"
+                      onClick={() =>
+                        (window.location.href = `/protected/scan-history/${scan.id}`)
+                      }
+                    >
                       <td className="py-2 pr-4">
-                        <img
-                          src={scan.image_url}
-                          alt={scan.predicted_label}
-                          className="h-12 w-12 object-cover rounded-md border"
-                        />
+                        <Link
+                          href={`/protected/scan-history/${scan.id}`}
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          <img
+                            src={scan.image_url}
+                            alt={scan.predicted_label}
+                            className="h-12 w-12 object-cover rounded-md border"
+                          />
+                        </Link>
                       </td>
                       <td className="py-2 pr-4 font-medium">
-                        {scan.predicted_label}
+                        <Link
+                          href={`/protected/scan-history/${scan.id}`}
+                          className="hover:underline"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          {scan.predicted_label}
+                        </Link>
                       </td>
                       <td className="py-2 pr-4">
                         {(scan.confidence * 100).toFixed(1)}%
@@ -80,11 +97,6 @@ const ScanHistoryView = () => {
                       <td className="py-2 pr-4">{scan.model_version}</td>
                       <td className="py-2 pr-4">
                         {new Date(scan.created_at).toLocaleString()}
-                      </td>
-                      <td className="py-2 pr-4">
-                        <Link href={`scan-history/${scan.id}`} className="">
-                          View
-                        </Link>
                       </td>
                     </tr>
                   ))}


### PR DESCRIPTION
This pull request adds detailed scan history viewing functionality, allowing users to see individual scan details including disease information and treatments. It introduces a new hook for fetching scan details, updates the scan history inner page to display rich information, and improves navigation between scan history and scan details. The most important changes are grouped below.

**Scan Details Fetching and Display:**

* Added a new hook `useScanDetails` in `src/hooks/use-scan-details.ts` that uses React Query to fetch scan details, including disease info and treatments, by scan ID and access token.
* Implemented a new API function `getScanById` in `src/services/scan.services.ts` to retrieve scan details from the backend.
* Updated `ScanHistoryInnerPage` in `src/view/scan-history-inner-page/ScanHistoryInnerPage.tsx` to display scan image, prediction details, disease description, top predictions, and treatments, with loading and error states.

**Navigation and Routing Improvements:**

* Changed the scan history table rows in `src/view/scan-history/ScanHistoryView.tsx` to be clickable, navigating to the scan details page, and improved accessibility by wrapping image and label in links that prevent event propagation.
* Removed the "View" link column from the scan history table, as the row itself now navigates to the scan details page.
* Simplified the page component in `src/app/(protected)/scan-history/[scanId]/page.tsx` to accept `params` directly, removing unnecessary async/await logic. ([src/app/(protected)/scan-history/[scanId]/page.tsxL3-R8](diffhunk://#diff-6de0d4981317418b6556749e9a9ba89a12a97adde29fe7c91df8caf2c82ee528L3-R8))