### PR TITLE
Feat/scan history

### DIFF
--- a/src/app/(protected)/scan-history/[scanId]/page.tsx
+++ b/src/app/(protected)/scan-history/[scanId]/page.tsx
@@ -1,10 +1,10 @@
 import ScanHistoryInnerPage from "@/view/scan-history-inner-page/ScanHistoryInnerPage";
 
-export default function ScanInnerPage({
+export default async function ScanInnerPage({
   params,
 }: {
   params: { scanId: string };
 }) {
-  const { scanId } = params;
+  const { scanId } = await params;
   return <ScanHistoryInnerPage scanId={scanId} />;
 }

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -33,6 +33,9 @@ const Header = () => {
           <Link href={"/scan"} className="text-white">
             Scan
           </Link>
+          <Link href={"/scan-history"} className="text-white">
+            Scan History
+          </Link>
           <div className="relative" ref={menuRef}>
             {session ? (
               <>

--- a/src/view/scan-history-inner-page/ScanHistoryInnerPage.tsx
+++ b/src/view/scan-history-inner-page/ScanHistoryInnerPage.tsx
@@ -68,7 +68,7 @@ const ScanHistoryInnerPage: React.FC<ScanHistoryInnerPageProps> = ({
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-semibold">Scan Details</h1>
         <Button asChild variant="outline" size="sm">
-          <Link href="/protected/scan-history">Back to history</Link>
+          <Link href="/scan-history">Back to history</Link>
         </Button>
       </div>
 

--- a/src/view/scan-history/ScanHistoryView.tsx
+++ b/src/view/scan-history/ScanHistoryView.tsx
@@ -67,12 +67,12 @@ const ScanHistoryView = () => {
                       key={scan.id}
                       className="border-b last:border-none hover:bg-muted/40 cursor-pointer"
                       onClick={() =>
-                        (window.location.href = `/protected/scan-history/${scan.id}`)
+                        (window.location.href = `/scan-history/${scan.id}`)
                       }
                     >
                       <td className="py-2 pr-4">
                         <Link
-                          href={`/protected/scan-history/${scan.id}`}
+                          href={`/scan-history/${scan.id}`}
                           onClick={(e) => e.stopPropagation()}
                         >
                           <img
@@ -84,7 +84,7 @@ const ScanHistoryView = () => {
                       </td>
                       <td className="py-2 pr-4 font-medium">
                         <Link
-                          href={`/protected/scan-history/${scan.id}`}
+                          href={`/scan-history/${scan.id}`}
                           className="hover:underline"
                           onClick={(e) => e.stopPropagation()}
                         >


### PR DESCRIPTION
This pull request updates the routing for scan history pages to simplify URLs and improve navigation. The main changes include removing the `/protected` prefix from scan history routes, updating related links throughout the app, and adding a direct navigation option to scan history in the header.

**Routing and Navigation Updates:**

* Removed `/protected` prefix from scan history routes in navigation, scan detail view, and scan history list, ensuring consistency across the application. [[1]](diffhunk://#diff-eef29e25e14aeacbabc0a833faa442cc88d70d9bc3b86b071a1297c6e2318714L71-R71) [[2]](diffhunk://#diff-9c79080bd17d1769840d1e6a65305df32f659ddc0156a69b6b69f60ace78da29L70-R75) [[3]](diffhunk://#diff-9c79080bd17d1769840d1e6a65305df32f659ddc0156a69b6b69f60ace78da29L87-R87)
* Added a "Scan History" link to the header for easier access.

**Page Component Update:**

* Updated the `ScanInnerPage` component to be asynchronous and adjusted how it receives route parameters, aligning with Next.js conventions. ([src/app/(protected)/scan-history/[scanId]/page.tsxL3-R8](diffhunk://#diff-6de0d4981317418b6556749e9a9ba89a12a97adde29fe7c91df8caf2c82ee528L3-R8))